### PR TITLE
투표 신고, 계정 정지, 회원 탈퇴, 세션 id 기능 수정

### DIFF
--- a/src/main/java/com/mjuAppSW/joA/domain/member/Member.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/member/Member.java
@@ -9,7 +9,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
-import java.util.Date;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -128,5 +127,10 @@ public class Member {
 
     public void addReportCount() {
         this.reportCount++;
+    }
+
+    public void deleteStopDate() {
+        this.stopStartDate = null;
+        this.stopEndDate = null;
     }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/member/MemberAccessor.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/member/MemberAccessor.java
@@ -28,7 +28,7 @@ public class MemberAccessor {
         if (member == null) {
             return false;
         }
-        if (member.getStatus() == 1 && member.getStatus() == 2) {
+        if (member.getStatus() == 1 || member.getStatus() == 2) {
             return true;
         }
         return false;

--- a/src/main/java/com/mjuAppSW/joA/domain/member/MemberServiceImpl.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/member/MemberServiceImpl.java
@@ -95,7 +95,7 @@ public class MemberServiceImpl implements MemberService{
         if(isUsingMail(eMail))
             return new UMailResponse(MAIL_IS_USING);
 
-        long sessionId = sessionManager.getSessionId();
+        long sessionId = sessionManager.makeSessionId();
         String certifyNum = cacheCertifyNumAndEmail(sessionId, eMail);
         sendCertifyNumMail(request.getUEmail(), college.getDomain(), certifyNum);
         return new UMailResponse(NORMAL_OPERATION, sessionId);
@@ -194,11 +194,7 @@ public class MemberServiceImpl implements MemberService{
         if (isNull(findMember))
             return new LoginResponse(LOGIN_ID_IS_NOT_EXISTED);
 
-        Long sessionId = findMember.getSessionId();
-        if (!isNull(sessionId))
-            return new LoginResponse(LOGIN_IS_ALREADY);
-
-        findMember.makeSessionId(sessionManager.getSessionId());
+        findMember.makeSessionId(sessionManager.makeSessionId());
         // 비밀번호 암호화
         String salt = findMember.getSalt();
         String hashedPassword = BCrypt.hashpw(request.getPassword(), salt);

--- a/src/main/java/com/mjuAppSW/joA/domain/member/MemberStatusManager.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/member/MemberStatusManager.java
@@ -1,6 +1,7 @@
 package com.mjuAppSW.joA.domain.member;
 
 import static com.mjuAppSW.joA.constant.Constants.EMPTY_STRING;
+import static java.util.Objects.isNull;
 
 import com.mjuAppSW.joA.geography.location.LocationRepository;
 import com.mjuAppSW.joA.storage.S3Uploader;
@@ -27,20 +28,20 @@ public class MemberStatusManager {
     public void check() {
         List<Member> joiningAll = memberRepository.findJoiningAll();
         for (Member member : joiningAll) {
-            if (member.getReportCount() == 5 && member.getStatus() == 0) {
-                executeStopPolicy(member, member.getReportCount());
+            if (member.getReportCount() >= 5 && member.getStatus() != 11) {
+                executeStopPolicy(member, 5);
             }
-            if (member.getReportCount() == 10 && member.getStatus() == 11) {
-                executeStopPolicy(member, member.getReportCount());
+            if (member.getReportCount() >= 10 && member.getStatus() != 22) {
+                executeStopPolicy(member, 10);
             }
-            if (member.getReportCount() == 15 && member.getStatus() == 22) {
+            if (member.getReportCount() >= 15) {
                 executeOutPolicy(member);
             }
         }
     }
 
     private void executeStopPolicy(Member member, int reportCount) {
-        if (member.getStopEndDate() == LocalDate.now()) {
+        if (!isNull(member.getStopEndDate()) && member.getStopEndDate() == LocalDate.now()) {
            completeStopPolicy(member, reportCount);
            return;
         }
@@ -69,6 +70,7 @@ public class MemberStatusManager {
             member.changeStatus(22);
             log.info("account stop end : id = {}, reportCount = 10", member.getId());
         }
+        member.deleteStopDate();
     }
 
     private void executeOutPolicy(Member member) {

--- a/src/main/java/com/mjuAppSW/joA/domain/member/MemberStatusManager.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/member/MemberStatusManager.java
@@ -53,10 +53,12 @@ public class MemberStatusManager {
         member.changeStopStartDate(today);
         if (reportCount == 5) {
             member.changeStopEndDate(today.plusDays(1));
+            member.changeStatus(1);
             log.info("account stop start : id = {}, reportCount = 5", member.getId());
         }
         if (reportCount == 10) {
             member.changeStopEndDate(today.plusDays(7));
+            member.changeStatus(2);
             log.info("account stop start : id = {}, reportCount = 10", member.getId());
         }
     }

--- a/src/main/java/com/mjuAppSW/joA/domain/member/MemberStatusManager.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/member/MemberStatusManager.java
@@ -28,10 +28,12 @@ public class MemberStatusManager {
     public void check() {
         List<Member> joiningAll = memberRepository.findJoiningAll();
         for (Member member : joiningAll) {
-            if (member.getReportCount() >= 5 && member.getStatus() != 11) {
+            if (member.getReportCount() >= 5 && member.getStatus() != 1 && member.getStatus() != 2
+                    && member.getStatus() != 11 && member.getStatus() != 22) {
                 executeStopPolicy(member, 5);
             }
-            if (member.getReportCount() >= 10 && member.getStatus() != 22) {
+            if (member.getReportCount() >= 10 && member.getStatus() != 1 && member.getStatus() != 2
+                    && member.getStatus() != 22) {
                 executeStopPolicy(member, 10);
             }
             if (member.getReportCount() >= 15) {

--- a/src/main/java/com/mjuAppSW/joA/domain/report/vote/VoteReportService.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/report/vote/VoteReportService.java
@@ -16,7 +16,6 @@ import com.mjuAppSW.joA.domain.vote.VoteRepository;
 import com.mjuAppSW.joA.domain.vote.dto.StatusResponse;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -46,6 +45,7 @@ public class VoteReportService {
 
         VoteReport voteReport = makeVoteReport(vote, reportCategory, request.getContent());
         voteReportRepository.save(voteReport);
+        vote.changeInvalid();
 
         Member giveMember = memberRepository.findById(vote.getGiveId()).orElse(null);
         if (giveMember != null) {

--- a/src/main/java/com/mjuAppSW/joA/domain/vote/Vote.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/vote/Vote.java
@@ -53,4 +53,8 @@ public class Vote {
         this.hint = hint;
         this.isValid = true;
     }
+
+    public void changeInvalid() {
+        this.isValid = false;
+    }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/vote/VoteRepository.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/vote/VoteRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface VoteRepository extends JpaRepository<Vote, Long> {
-    @Query("SELECT vc.name FROM Vote v JOIN v.voteCategory vc WHERE v.member.id = :id GROUP BY vc.name ORDER BY COUNT(vc.name) DESC")
+    @Query("SELECT vc.name FROM Vote v JOIN v.voteCategory vc WHERE v.member.id = :id AND v.isValid = true GROUP BY vc.name ORDER BY COUNT(vc.name) DESC")
     List<String> findVoteCategoryById(@Param("id") Long id, Pageable pageable);
 
     @Query("SELECT v FROM Vote v WHERE v.giveId = :giveId AND v.member.id = :takeId AND v.voteCategory.id = :categoryId AND v.date = :today")

--- a/src/main/java/com/mjuAppSW/joA/session/SessionManager.java
+++ b/src/main/java/com/mjuAppSW/joA/session/SessionManager.java
@@ -17,7 +17,7 @@ public class SessionManager {
 
     private final MemberRepository memberRepository;
 
-    public long getSessionId() {
+    public long makeSessionId() {
         long min = 1000000000L;
         long max = 9999999999L;
         return ThreadLocalRandom.current().nextLong(min, max + 1);
@@ -34,7 +34,7 @@ public class SessionManager {
     public void expiredSessionId() {
         List<Member> members = memberRepository.findAll();
         for (Member member : members) {
-            member.makeSessionId(getSessionId());
+            member.makeSessionId(makeSessionId());
         }
     }
 }


### PR DESCRIPTION
투표 신고 : 투표 신고 시 무효 투표로 설정, 투표함에 포함되지 않음, 투표 top3 카테고리 산정에 포함되지 않음
계정 정지/회원 탈퇴 : 현재 어떤 상태인지(정지 상태인지, 신고 카운트 조건이 충족된 상태인지, 이미 정지를 당한적이 있는지, ...) 따지는 조건 수정
세션 id : 로그인 시 무조건 새로운 세션 id 발급되는 것으로 변경(로그인되어 있던 다른 기기가 로그아웃 되도록 정책 변경)